### PR TITLE
Routine statistics

### DIFF
--- a/src/lib/db/models/Template.js
+++ b/src/lib/db/models/Template.js
@@ -80,9 +80,8 @@ const Template = {
   async getTotalStats ({ id }) {
     return new Promise(async (resolve) => {
       const q = query(
-        collection(db, "users", get(user).uid, "tasks"), 
+        collection(db, 'users', get(user).uid, 'tasks'), 
         where('templateID', '==', id), 
-        where('startDateISO', '<=', DateTime.now().toFormat('yyyy-MM-dd')), 
         where('isDone', '==', true)
       )
       const snapshot = await getDocs(q)

--- a/src/lib/db/models/Template.js
+++ b/src/lib/db/models/Template.js
@@ -19,7 +19,7 @@ const Template = {
     timeZone: z.string(),
     notes: z.string().default(''),
     notify: z.string().default(''),
-    isStarred: z.boolean().default(false),
+    isStarred: z.boolean().default(true),
     imageDownloadURL: z.string().default(''),
     iconURL: z.string().default(''),
     rrStr: z.string().default(''),

--- a/src/lib/utils/core.js
+++ b/src/lib/utils/core.js
@@ -147,3 +147,8 @@ export function minutes (HHmm) {
   const [hours, minutes] = HHmm.split(':').map(Number)
   return hours * 60 + minutes
 }
+
+export function formatHours (minutes) {
+  const H = round(minutes / 60, 1)
+  return `${H} hr${H !== 1 ? 's' : ''}`
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -251,6 +251,10 @@
     display: flex;
   }
 
+  :global(.content-center) {
+    align-items: center;
+  }
+
   :global(.grid) {
     display: grid;
   }
@@ -277,6 +281,10 @@
 
   :global(.gap-0) {
     gap: 0;
+  }
+
+  :global(.gap-8) {
+    gap: 8px;
   }
 
   /* Hide scrollbar utility class - works cross-browser */

--- a/src/routes/[user]/components/Archive/JournalEntries.svelte
+++ b/src/routes/[user]/components/Archive/JournalEntries.svelte
@@ -131,10 +131,6 @@
     cursor: pointer;
   }
 
-  .entry-wrapper:hover {
-    opacity: 0.8;
-  }
-
   .journal-entry {
     width: 100%;
     padding-left: var(--content-start);

--- a/src/routes/[user]/components/Calendar/DayHeader.svelte
+++ b/src/routes/[user]/components/Calendar/DayHeader.svelte
@@ -142,9 +142,8 @@
 
 <style>
   .task-input {
-    margin-top: 4px;
     width: 100%; 
-    height: 24px;
+    height: 1rem;
     padding-left: 0px; 
     padding-right: 0px;
     pointer-events: none;

--- a/src/routes/[user]/components/Calendar/DayHeader.svelte
+++ b/src/routes/[user]/components/Calendar/DayHeader.svelte
@@ -87,6 +87,7 @@
 <div bind:this={dayHeader}
   class="day-header"
   style:padding={$isCompact ? '8px 0px' : 'var(--height-main-content-top-margin) 0px'}
+  style:padding-bottom="0"
   onclick={e => {
     e.stopPropagation()
     if (e.target !== e.currentTarget) return;
@@ -156,10 +157,7 @@
 
   .day-header {
     width: var(--width-calendar-day-section);
-    padding-top: var(--main-content-top-margin);
-    padding-bottom: 18px;
-
-    font-size: 1.4em;
+    font-size: 1.4rem;
     background-color: var(--calendar-bg-color);
     color: #6d6d6d;
   }

--- a/src/routes/[user]/components/TaskPopup/TaskPopupContent.svelte
+++ b/src/routes/[user]/components/TaskPopup/TaskPopupContent.svelte
@@ -15,7 +15,7 @@
   const { Task, tasksCache, clickedTaskID, closeTaskPopup, ancestralTree } = getContext('app')
   
   let taskObject = $derived($tasksCache[$clickedTaskID])
-  let showTemplateEditor = $state(false)
+  let showTemplateEditor = $state(taskObject.templateID)
 
   const debouncedUpdate = createDebouncedFunction(
     (id, keyValueChanges) => Task.update({ id, keyValueChanges }), 

--- a/src/routes/[user]/mobile/HabitsTab.svelte
+++ b/src/routes/[user]/mobile/HabitsTab.svelte
@@ -47,8 +47,7 @@
     else selectedRoutineID = routineID
   }
 
-  function getBarWidth(minutes) {
-    if (!maxMinutesSpent || !minutes) return 0
+  function getBarWidth (minutes) {
     return (minutes / maxMinutesSpent) * 75 // Scale to max 75% to leave room for hours text
   }
 </script>
@@ -165,7 +164,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    min-width: 0; /* Allow flex item to shrink below content size */
+    min-width: 0; 
   }
 
   .routine-bar-wrapper {
@@ -186,15 +185,6 @@
     min-width: 2px;
     flex-shrink: 1; /* Allow bar to shrink if needed */
     max-width: 100%; /* Prevent bar from exceeding wrapper */
-  }
-
-  .routine-hours {
-    font-size: var(--font-size-sm, 0.875rem);
-    color: #666;
-    font-weight: 500;
-    white-space: nowrap;
-    flex-shrink: 0;
-    min-width: fit-content;
   }
 
   .overflow-routines-grid {
@@ -248,16 +238,5 @@
 
   .menu-item.selected {
     background: rgba(0, 89, 125, 0.08);
-  }
-
-  .menu-icon-placeholder {
-    width: 24px;
-    height: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: #f5f5f5;
-    border-radius: 4px;
-    flex-shrink: 0;
   }
 </style>

--- a/src/routes/[user]/mobile/HabitsTab.svelte
+++ b/src/routes/[user]/mobile/HabitsTab.svelte
@@ -13,7 +13,7 @@
   let selectedRoutineID = $state('')
   let stats = $state(new Map())
 
-  let maxMinutesSpent = $derived(Math.max(0, ...Array.from(stats.values()).map(s => s.minutesSpent)))
+  let maxMinutesSpent = $derived(Math.max(1, ...Array.from(stats.values()).map(s => s.minutesSpent)))
   let unstarredRoutines = $derived($templates.filter(r => !r.isStarred))
   let starredRoutines = $derived($templates.filter(r => r.isStarred))
   let topRoutines = $derived([...starredRoutines].sort((a, b) => {
@@ -79,7 +79,7 @@
       {/each}
     </div>
     
-    {#if unstarredRoutines}
+    {#if unstarredRoutines.length > 0}
       <div class="overflow-routines-grid">        
         <PopoverMenu {activator} {content} />
       </div>

--- a/src/routes/[user]/mobile/HabitsTab.svelte
+++ b/src/routes/[user]/mobile/HabitsTab.svelte
@@ -1,91 +1,33 @@
 <script>
-  import { user } from '$lib/store'
+  import HabitsTabFullDetails from './HabitsTabFullDetails.svelte'
+  import TemplatePopup from '../components/Templates/components/TemplatePopup/TemplatePopup.svelte'
+  import PopoverMenu from '$lib/components/PopoverMenu.svelte'
+  import Template from '$lib/db/models/Template.js'
+  import { openTemplateEditor, templates, popup } from '../components/Templates/store.js'
+  import { formatHours } from '$lib/utils/core.js'
   import { collection, onSnapshot } from 'firebase/firestore'
   import { db } from '$lib/db/init.js'
-  import { onMount } from 'svelte'
-  import ListenToDoc from '../components/Archive/ListenToDoc.svelte'
-  import ListenToRoutineInstances from '../components/Archive/ListenToRoutineInstances.svelte'
-  import JournalEntries from '../components/Archive/JournalEntries.svelte'
-  import PopoverMenu from '$lib/components/PopoverMenu.svelte'
-  import StarButton from '$lib/components/StarButton.svelte'
-  import Template from '$lib/db/models/Template.js'
-  import { openTemplateEditor, templates, popup, template } from '../components/Templates/store.js'
-  import TemplatePopup from '../components/Templates/components/TemplatePopup/TemplatePopup.svelte'
-  import { round } from '$lib/utils/core.js'
+  import { getContext, onMount } from 'svelte'
 
-  function formatTime(minutes) {
-    const roundedMinutes = round(minutes, 0)
-    if (roundedMinutes < 60) return `${roundedMinutes} mins`
-    const hours = Math.floor(roundedMinutes / 60)
-    const remainingMinutes = roundedMinutes % 60
-    if (remainingMinutes === 0) {
-      return `${hours} hr${hours !== 1 ? 's' : ''}`
-    }
-    return `${hours} hr${hours !== 1 ? 's' : ''} ${remainingMinutes} min${remainingMinutes !== 1 ? 's' : ''}`
-  }
+  const { user } = getContext('app')
 
-  let routines = $state(null)
   let selectedRoutineID = $state('')
-  let routineStats = $state(new Map())
-  let maxMinutesSpent = $state(0)
-  let fetchedStats = new Set() // Track which routines we've fetched stats for
-  let statsLoaded = $state(false) // Track when stats have finished loading
+  let stats = $state(new Map())
 
-  // Fetch stats for starred routines (they're most likely to appear in top positions)
-  async function fetchStats(routines) {
-    const toFetch = routines
-      .filter(r => r.isStarred && !fetchedStats.has(r.id))
-    
-    if (toFetch.length === 0) {
-      statsLoaded = true
-      return
+  let maxMinutesSpent = $derived(Math.max(0, ...Array.from(stats.values()).map(s => s.minutesSpent)))
+  let starredRoutines = $derived.by(() => $templates.filter(r => r.isStarred))
+  let unstarredRoutines = $derived($templates.filter(r => !r.isStarred))
+
+  $effect(async () => {
+    for (const routine of starredRoutines) {
+      if (stats.has(routine.id)) continue 
+      else {
+        const result = await Template.getTotalStats({ id: routine.id })
+        stats.set(routine.id, result)
+        stats = new Map(stats) // force reactivity update
+      }
     }
-    
-    const results = await Promise.all(
-      toFetch.map(routine => 
-        Template.getTotalStats({ id: routine.id })
-          .then(stats => ({ id: routine.id, stats }))
-          .catch(() => ({ id: routine.id, stats: { minutesSpent: 0, timesCompleted: 0 } }))
-      )
-    )
-    
-    let maxTime = 0
-    results.forEach(({ id, stats }) => {
-      fetchedStats.add(id)
-      routineStats.set(id, stats)
-      maxTime = Math.max(maxTime, stats.minutesSpent || 0)
-    })
-    
-    // Include existing stats in max calculation
-    routineStats.forEach(stats => {
-      maxTime = Math.max(maxTime, stats.minutesSpent || 0)
-    })
-    
-    maxMinutesSpent = maxTime
-    routineStats = new Map(routineStats) // trigger reactivity
-    statsLoaded = true
-  }
-
-  // Single sorted list with clear priority: starred+icon > starred > icon > rest, then by stats
-  let sortedRoutines = $derived.by(() => {
-    if (!routines) return []
-    return [...routines].sort((a, b) => {
-      // Priority score: starred+icon (3), starred (2), icon (1), neither (0)
-      const score = r => (r.isStarred ? 2 : 0) + (r.iconURL ? 1 : 0)
-      const scoreDiff = score(b) - score(a)
-      if (scoreDiff !== 0) return scoreDiff
-      // Then by time spent
-      const statsA = routineStats.get(a.id)?.minutesSpent || 0
-      const statsB = routineStats.get(b.id)?.minutesSpent || 0
-      if (statsA !== statsB) return statsB - statsA
-      // Then alphabetically
-      return (a.name || '').localeCompare(b.name || '')
-    })
   })
-
-  // Top 3 get the bar treatment, rest go to overflow
-  let topRoutines = $derived(sortedRoutines.slice(0, 3))
-  let overflowRoutines = $derived(sortedRoutines.slice(3))
 
   onMount(async () => {
     listenToRoutines()
@@ -94,105 +36,53 @@
   async function listenToRoutines() {
     const ref = collection(db, '/users/' + $user.uid + '/templates')
     onSnapshot(ref, async (querySnapshot) => {
-      const temp = querySnapshot.docs.map(doc => ({ ...doc.data(), id: doc.id }))
-      temp.sort((a, b) => {
-        if (a.isStarred && !b.isStarred) return -1
-        if (!a.isStarred && b.isStarred) return 1
-        return (a.name || '').localeCompare(b.name || '')
-      })
-      routines = temp
-      templates.set(temp)
-      
-      // Fetch stats for starred routines
-      statsLoaded = false
-      await fetchStats(routines)
-      
-      // Auto-select first routine (sortedRoutines already has correct priority)
-      if (!selectedRoutineID && routines.length > 0) {
-        selectedRoutineID = sortedRoutines[0]?.id
-      }
+      templates.set(
+        querySnapshot.docs.map(doc => ({ ...doc.data(), id: doc.id })
+      ))
     })
   }
 
-  function selectHabit(routineID) {
-    if (selectedRoutineID === routineID) {
-      openTemplateEditor(routineID)
-    } else {
-      selectedRoutineID = routineID
-    }
+  function select (routineID) {
+    if (selectedRoutineID === routineID) openTemplateEditor(routineID)
+    else selectedRoutineID = routineID
   }
 
   function getBarWidth(minutes) {
     if (!maxMinutesSpent || !minutes) return 0
-    // Scale to max 75% to leave room for hours text
-    return (minutes / maxMinutesSpent) * 75
-  }
-
-  function formatHours(minutes) {
-    if (!minutes) return '0 hrs'
-    const roundedMinutes = round(minutes, 0)
-    const hours = Math.floor(roundedMinutes / 60)
-    return `${hours} hr${hours !== 1 ? 's' : ''}`
-  }
-
-  async function toggleStar (routineID, value) {
-    await Template.update({ id: routineID, updates: { isStarred: !value } })
+    return (minutes / maxMinutesSpent) * 75 // Scale to max 75% to leave room for hours text
   }
 </script>
 
-<div class="habits-view">
-  <div class="routines-section">
-    {#if routines?.length > 0 && statsLoaded}
-      <!-- Top routines with bars -->
-      <div class="top-routines-list">
-        {#each topRoutines as routine (routine.id)}
-          <button 
-            class="routine-row"
-            class:selected={selectedRoutineID === routine.id}
-            onclick={() => selectHabit(routine.id)}
-          >
-            {#if routine.iconURL}
-              <img src={routine.iconURL} alt={routine.name} class="routine-icon" />
-              <div class="routine-bar-container">
-                {#if routineStats.has(routine.id)}
-                  {@const stats = routineStats.get(routine.id)}
-                  <div class="routine-bar-wrapper">
-                    <div class="routine-bar" style="width: {getBarWidth(stats.minutesSpent)}%"></div>
-                    <span class="routine-hours">{formatHours(stats.minutesSpent)}</span>
-                  </div>
-                {/if}
+<div class="habits-view" style="width: 100%;">
+  {#if starredRoutines?.length > 0}
+    <div style="display: flex; flex-direction: column; padding: 0 4px;">
+      {#each starredRoutines as routine (routine.id)}
+        <button onclick={() => select(routine.id)}
+          class="routine-row"
+          class:selected={selectedRoutineID === routine.id}
+        >
+          {@render routineItem({ routine })}
+
+          {#if stats.has(routine.id)}
+            <div class="routine-bar-container">
+              <div class="routine-bar-wrapper">
+                <div class="routine-bar" style="width: {getBarWidth(stats.get(routine.id).minutesSpent)}%"></div>
+                <span class="routine-hours">{formatHours(stats.get(routine.id).minutesSpent)}</span>
               </div>
-            {:else}
-              <span class="routine-name-text">{routine.name}</span>
-              {#if routineStats.has(routine.id)}
-                {@const stats = routineStats.get(routine.id)}
-                <span class="routine-hours">{formatHours(stats.minutesSpent)}</span>
-              {/if}
-            {/if}
-          </button>
-        {/each}
-      </div>
-      
-      <!-- Overflow routines -->
-      {#if overflowRoutines.length > 0}
-        <div class="overflow-routines-grid">
-          {#each overflowRoutines.filter(r => r.iconURL) as routine (routine.id)}
-            <button 
-              class="routine-compact"
-              class:selected={selectedRoutineID === routine.id}
-              onclick={() => selectHabit(routine.id)}
-            >
-              <img src={routine.iconURL} alt={routine.name} class="routine-icon-compact" />
-            </button>
-          {/each}
-          
-          {#if overflowRoutines.some(r => !r.iconURL)}
-            <PopoverMenu {activator} {content} />
+            </div>
           {/if}
-        </div>
-      {/if}
+        </button>
+      {/each}
+    </div>
+    
+    {#if unstarredRoutines.length > 0}
+      <div class="overflow-routines-grid">        
+        {#if unstarredRoutines.some(r => !r.iconURL)}
+          <PopoverMenu {activator} {content} />
+        {/if}
+      </div>
     {/if}
-  </div>
+  {/if}
 
   {#snippet activator({ setPosition, popovertarget })}
     <button {popovertarget} onclick={setPosition} class="routine-compact more-button">
@@ -202,64 +92,33 @@
 
   {#snippet content({ close })}
     <div class="more-menu-content">
-      {#each overflowRoutines.filter(r => !r.iconURL) as routine (routine.id)}
-        <button 
+      {#each unstarredRoutines as routine (routine.id)}
+        <button onclick={() => { select(routine.id); close(); }}
           class="menu-item"
           class:selected={selectedRoutineID === routine.id}
-          onclick={() => { selectHabit(routine.id); close(); }}
         >
-          <div class="menu-icon-placeholder">
-            <span class="material-symbols-outlined">task</span>
-          </div>
-          <span class="menu-name">{routine.name}</span>
+          {@render routineItem({ routine })}
         </button>
       {/each}
     </div>
   {/snippet}
 
   {#if selectedRoutineID}
-    <div class="routine-content-section">
-      <ListenToRoutineInstances 
-        templateID={selectedRoutineID}
-        userID={$user.uid}
-        let:routineInstances={instances}
-      >
-        <ListenToDoc docPath={'/users/' + $user.uid + '/templates/' + selectedRoutineID}
-          let:theDoc={selectedRoutine}
-        >
-          {#if selectedRoutine}
-            {@const stats = routineStats.get(selectedRoutineID)}
-            <div class="routine-header">
-              <div class="routine-title-row">
-                <h2>{selectedRoutine.name}</h2>
-                <StarButton 
-                  isStarred={selectedRoutine.isStarred}
-                  onToggle={() => toggleStar(selectedRoutineID, selectedRoutine.isStarred)}
-                />
-              </div>
-              {#if stats}
-                <div class="routine-stats">
-                  <span class="stat-item">{formatTime(stats.minutesSpent)}</span>
-                  <span class="stat-divider">•</span>
-                  <span class="stat-item">completed {stats.timesCompleted} times</span>
-                </div>
-              {/if}
-            </div>
-            
-            <div class="journal-entries-wrapper">
-              <JournalEntries 
-                routineInstances={instances}
-              />
-            </div>
-          {/if}
-        </ListenToDoc>
-      </ListenToRoutineInstances>
-    </div>
+    <HabitsTabFullDetails {selectedRoutineID} {stats} />
   {/if}
 
-  {#if $popup && $template}
+  {#if $popup}
     <TemplatePopup />
   {/if}
+
+  {#snippet routineItem({ routine })}
+    <div class="flexbox content-center" style="width: 240px;">
+      {#if routine.iconURL}
+        <img src={routine.iconURL} alt={routine.name} class="routine-icon" />
+      {/if}
+      <span>{routine.name}</span>
+    </div>
+  {/snippet}
 </div>
 
 <style>
@@ -271,37 +130,19 @@
     --routine-compact-padding: 2px;
   }
 
-  .routines-section {
-    flex-shrink: 0;
-  }
-
-  .routine-content-section {
+  .scrollable-flexbox {
     flex: 1;
     display: flex;
     flex-direction: column;
     min-height: 0;
   }
 
-  .top-routines-list {
-    display: flex;
-    flex-direction: column;
-    padding: 0 4px;
-  }
-
   .routine-row {
     display: flex;
     align-items: center;
     column-gap: 8px;
-    padding: 8px 12px;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    border-radius: 6px;
+    padding: 8px;
     min-height: 48px;
-  }
-
-  .routine-row:hover {
-    background: rgba(0, 0, 0, 0.04);
   }
 
   .routine-row.selected {
@@ -312,17 +153,6 @@
     width: 48px;
     height: 48px;
     object-fit: contain;
-    flex-shrink: 0;
-  }
-
-  .routine-name-text {
-    flex: 1;
-    font-size: var(--font-size-md);
-    color: #333;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    text-align: left;
   }
 
   .routine-bar-container {
@@ -379,18 +209,10 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: var(--routine-compact-padding);
-    border: none;
-    background: transparent;
-    cursor: pointer;
     border-radius: 6px;
+    padding: var(--routine-compact-padding);
     width: var(--routine-compact-size);
     height: var(--routine-compact-size);
-    box-sizing: border-box;
-  }
-
-  .routine-compact:hover {
-    background: rgba(0, 0, 0, 0.04);
   }
 
   .routine-compact.selected {
@@ -404,14 +226,8 @@
     flex-shrink: 0;
   }
 
-  .more-button {
-    background: transparent;
-  }
-
   .more-icon {
     font-size: var(--font-size-xxl);
-    color: #666;
-    line-height: 1;
   }
 
   .more-menu-content {
@@ -426,16 +242,8 @@
     align-items: center;
     gap: 12px;
     padding: 12px;
-    border: none;
-    background: transparent;
     border-radius: 8px;
-    cursor: pointer;
-    transition: all 0.15s;
     text-align: left;
-  }
-
-  .menu-item:hover {
-    background: #f5f5f5;
   }
 
   .menu-item.selected {
@@ -451,53 +259,5 @@
     background: #f5f5f5;
     border-radius: 4px;
     flex-shrink: 0;
-  }
-
-  .menu-icon-placeholder .material-symbols-outlined {
-    font-size: var(--font-size-lg);
-    color: #999;
-  }
-
-  .menu-name {
-    font-size: var(--font-size-md);
-    color: #333;
-    flex: 1;
-  }
-
-  .routine-header {
-    flex-shrink: 0;
-    margin-bottom: 20px;
-    padding: 0 16px;
-  }
-
-  .journal-entries-wrapper {
-    flex: 1;
-    min-height: 0;
-  }
-
-  .routine-title-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 8px;
-  }
-
-  .routine-header h2 {
-    margin: 0;
-    font-size: var(--font-size-xxl);
-    font-weight: 600;
-    flex: 1;
-  }
-
-  .routine-stats {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    color: #666;
-    font-size: var(--font-size-md);
-  }
-
-  .stat-divider {
-    color: #ccc;
   }
 </style>

--- a/src/routes/[user]/mobile/HabitsTab.svelte
+++ b/src/routes/[user]/mobile/HabitsTab.svelte
@@ -2,36 +2,41 @@
   import HabitsTabFullDetails from './HabitsTabFullDetails.svelte'
   import TemplatePopup from '../components/Templates/components/TemplatePopup/TemplatePopup.svelte'
   import PopoverMenu from '$lib/components/PopoverMenu.svelte'
-  import Template from '$lib/db/models/Template.js'
   import { openTemplateEditor, templates, popup } from '../components/Templates/store.js'
   import { formatHours } from '$lib/utils/core.js'
   import { collection, onSnapshot } from 'firebase/firestore'
   import { db } from '$lib/db/init.js'
   import { getContext, onMount } from 'svelte'
 
-  const { user } = getContext('app')
+  const { user, Template } = getContext('app')
 
   let selectedRoutineID = $state('')
   let stats = $state(new Map())
 
   let maxMinutesSpent = $derived(Math.max(0, ...Array.from(stats.values()).map(s => s.minutesSpent)))
-  let starredRoutines = $derived.by(() => $templates.filter(r => r.isStarred))
   let unstarredRoutines = $derived($templates.filter(r => !r.isStarred))
+  let starredRoutines = $derived($templates.filter(r => r.isStarred))
+  let topRoutines = $derived([...starredRoutines].sort((a, b) => {
+    return (stats.get(b.id)?.minutesSpent ?? 0) - (stats.get(a.id)?.minutesSpent ?? 0)
+  }))
 
   $effect(async () => {
     for (const routine of starredRoutines) {
-      if (stats.has(routine.id)) continue 
-      else {
-        const result = await Template.getTotalStats({ id: routine.id })
-        stats.set(routine.id, result)
-        stats = new Map(stats) // force reactivity update
-      }
+      fetchStatsIfNeeded(routine) // don't expose variables to $effect to avoid infinit rerenders
     }
   })
 
   onMount(async () => {
     listenToRoutines()
   })
+
+  async function fetchStatsIfNeeded (routine) {
+    if (!stats.has(routine.id)) {
+      const result = await Template.getTotalStats({ id: routine.id })
+      stats.set(routine.id, result)
+      stats = new Map(stats) // force reactivity update
+    }
+  }
 
   async function listenToRoutines() {
     const ref = collection(db, '/users/' + $user.uid + '/templates')
@@ -52,10 +57,10 @@
   }
 </script>
 
-<div class="habits-view" style="width: 100%;">
-  {#if starredRoutines?.length > 0}
+<div class="habits-view">
+  {#if topRoutines}
     <div style="display: flex; flex-direction: column; padding: 0 4px;">
-      {#each starredRoutines as routine (routine.id)}
+      {#each topRoutines as routine (routine.id)}
         <button onclick={() => select(routine.id)}
           class="routine-row"
           class:selected={selectedRoutineID === routine.id}
@@ -74,11 +79,9 @@
       {/each}
     </div>
     
-    {#if unstarredRoutines.length > 0}
+    {#if unstarredRoutines}
       <div class="overflow-routines-grid">        
-        {#if unstarredRoutines.some(r => !r.iconURL)}
-          <PopoverMenu {activator} {content} />
-        {/if}
+        <PopoverMenu {activator} {content} />
       </div>
     {/if}
   {/if}
@@ -122,9 +125,7 @@
 
 <style>
   .habits-view {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
+    width: 100vw;
     --routine-compact-size: 40px;
     --routine-compact-padding: 2px;
   }
@@ -178,13 +179,11 @@
   }
 
   .routine-bar {
-    height: 5px;
+    transition: width 0.3s ease;
+    height: 6px;
     background: #4caf50;
     border-radius: 3px;
-    transition: width 0.3s ease;
     min-width: 2px;
-    flex-shrink: 1; /* Allow bar to shrink if needed */
-    max-width: 100%; /* Prevent bar from exceeding wrapper */
   }
 
   .overflow-routines-grid {

--- a/src/routes/[user]/mobile/HabitsTab.svelte
+++ b/src/routes/[user]/mobile/HabitsTab.svelte
@@ -114,7 +114,7 @@
   {/if}
 
   {#snippet routineItem({ routine })}
-    <div class="flexbox content-center" style="width: 240px;">
+    <div class="flexbox content-center" style="width: 200px;">
       {#if routine.iconURL}
         <img src={routine.iconURL} alt={routine.name} class="routine-icon" />
       {/if}
@@ -140,8 +140,8 @@
   .routine-row {
     display: flex;
     align-items: center;
-    column-gap: 8px;
-    padding: 8px;
+    column-gap: 16px;
+    padding: 4px;
     min-height: 48px;
   }
 

--- a/src/routes/[user]/mobile/HabitsTabFullDetails.svelte
+++ b/src/routes/[user]/mobile/HabitsTabFullDetails.svelte
@@ -1,0 +1,73 @@
+<script>
+  import ListenToDoc from '../components/Archive/ListenToDoc.svelte'
+  import ListenToRoutineInstances from '../components/Archive/ListenToRoutineInstances.svelte'
+  import JournalEntries from '../components/Archive/JournalEntries.svelte'
+  import StarButton from '$lib/components/StarButton.svelte'
+  import { formatHours } from '$lib/utils/core.js'
+  import { getContext } from 'svelte'
+
+  const { user } = getContext('app')
+
+  let { selectedRoutineID, stats } = $props()
+
+  async function toggleStar (routineID, value) {
+    await Template.update({ id: routineID, updates: { isStarred: !value } })
+  }
+</script>
+
+
+<ListenToRoutineInstances templateID={selectedRoutineID} userID={$user.uid}
+  let:routineInstances={instances}
+>
+  <ListenToDoc docPath={'/users/' + $user.uid + '/templates/' + selectedRoutineID}
+    let:theDoc={selectedRoutine}
+  >
+    {#if selectedRoutine}
+      <div class="routine-header">
+        <div class="routine-title-row">
+          <h2>{selectedRoutine.name}</h2>
+          <StarButton isStarred={selectedRoutine.isStarred}
+            onToggle={() => toggleStar(selectedRoutineID, selectedRoutine.isStarred)}
+          />
+        </div>
+        {#if stats.has(selectedRoutineID)}
+          <div class="flexbox content-center gap-8">
+            <span>{formatHours(stats.get(selectedRoutineID).minutesSpent)}</span>
+            <span style="color: #666;">•</span>
+            <span>completed {stats.get(selectedRoutineID).timesCompleted} times</span>
+          </div>
+        {/if}
+      </div>
+      
+      <div class="journal-entries-wrapper">
+        <JournalEntries routineInstances={instances}/>
+      </div>
+    {/if}
+  </ListenToDoc>
+</ListenToRoutineInstances>
+
+<style>
+  .routine-header {
+    flex-shrink: 0;
+    margin-bottom: 20px;
+    padding: 0 16px;
+  }
+
+  .routine-header h2 {
+    margin: 0;
+    font-size: var(--font-size-xxl);
+    font-weight: 600;
+  }
+
+  .routine-title-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+
+  .journal-entries-wrapper {
+    flex: 1;
+    min-height: 0;
+  }
+</style>

--- a/src/routes/[user]/mobile/HabitsTabFullDetails.svelte
+++ b/src/routes/[user]/mobile/HabitsTabFullDetails.svelte
@@ -6,7 +6,7 @@
   import { formatHours } from '$lib/utils/core.js'
   import { getContext } from 'svelte'
 
-  const { user } = getContext('app')
+  const { user, Template } = getContext('app')
 
   let { selectedRoutineID, stats } = $props()
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a stats-driven Habits mobile UI with a new details panel, adds `formatHours`, changes template defaults (starred by default), and updates stats to include all completed tasks.
> 
> - **Mobile (Habits)**:
>   - **New details view**: Add `src/routes/[user]/mobile/HabitsTabFullDetails.svelte` showing routine header, star toggle, aggregated stats, and journal entries.
>   - **Habits list refactor**: `HabitsTab.svelte` now sorts starred routines by total minutes, fetches stats on demand via `Template.getTotalStats`, shows progress bars with `formatHours`, and moves unstarred routines into a popover.
> - **Models**:
>   - `Template.schema`: default `isStarred` set to `true`.
>   - `Template.getTotalStats`: counts all completed tasks (removed date filter); minor path quoting cleanup.
> - **Utils**:
>   - Add `formatHours(minutes)` in `src/lib/utils/core.js`.
> - **UI/Styling**:
>   - `+layout.svelte`: add utility classes `content-center` and `gap-8`.
>   - `DayHeader.svelte`: adjust paddings and sizes; use `1.4rem` font size; smaller task-input height.
>   - `TaskPopupContent.svelte`: template editor opens by default when `templateID` exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f70d57cbf98e6f0f1f27900f2675bb0ac0e1005. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->