### PR TITLE
User tags unexpected wipe

### DIFF
--- a/src/lib/db/helpers.js
+++ b/src/lib/db/helpers.js
@@ -1,7 +1,7 @@
 import {
   doc, setDoc, getDoc, updateDoc, deleteDoc,
   collection, getDocs, query, where, limit,
-  writeBatch, arrayRemove
+  writeBatch, arrayRemove, deleteField
 } from 'firebase/firestore'
 import { db } from './init'
 import { deleteObject, getStorage, ref } from 'firebase/storage'
@@ -106,9 +106,26 @@ async function deleteImage ({ imageFullPath }) {
   await deleteObject(ref(storage, imageFullPath))
 } 
 
-export async function deleteColorTag ({ tagID, user }) {
+export async function createColorTag ({ uid, tagID, tag }) {
+  if (!uid || !tagID) return
+  return updateFirestoreDoc(`/users/${uid}`, {
+    [`tags.${tagID}`]: tag
+  })
+}
+
+export async function updateColorTag ({ uid, tagID, kvChanges }) {
+  if (!uid || !tagID || !kvChanges) return
+  const updateObject = {}
+  for (const [k, v] of Object.entries(kvChanges)) {
+    updateObject[`tags.${tagID}.${k}`] = v
+  }
+  if (Object.keys(updateObject).length === 0) return
+  return updateFirestoreDoc(`/users/${uid}`, updateObject)
+}
+
+export async function deleteColorTag ({ tagID, uid }) {
+  if (!uid || !tagID) return
   const batch = writeBatch(db)
-  const { uid } = user
   const affectedTasks = await getFirestoreQuery(
     query(
       collection(db, `/users/${uid}/tasks`),
@@ -121,10 +138,8 @@ export async function deleteColorTag ({ tagID, user }) {
     })
   }
 
-  const copy = {...user.tags}
-  delete copy[tagID]
   batch.update(firestoreRef(`/users/${uid}`), {
-    tags: copy 
+    [`tags.${tagID}`]: deleteField()
   })
 
   return await batch.commit()

--- a/src/lib/db/models/User.js
+++ b/src/lib/db/models/User.js
@@ -1,5 +1,7 @@
 import { z } from 'zod'
-import { setFirestoreDoc, updateFirestoreDoc } from '$lib/db/helpers.js'
+import { doc, runTransaction } from 'firebase/firestore'
+import { updateFirestoreDoc } from '$lib/db/helpers.js'
+import { db } from '$lib/db/init.js'
 import { user, firebaseAuth } from '$lib/store'
 import { get } from 'svelte/store'
 
@@ -37,10 +39,21 @@ const User = {
   }),
 
   async create () {
-    const validatedUser = User.schema.parse(get(firebaseAuth).currentUser)
-    return await setFirestoreDoc(`/users/${validatedUser.uid}`, 
-      validatedUser
-    )
+    const authUser = get(firebaseAuth).currentUser
+    if (!authUser) return
+
+    try {
+      const validatedUser = User.schema.parse(authUser)
+      const ref = doc(db, 'users', validatedUser.uid)
+
+      return await runTransaction(db, async (transaction) => {
+        const snap = await transaction.get(ref)
+        if (snap.exists()) return
+        transaction.set(ref, validatedUser)
+      })
+    } catch (error) {
+      console.error('error in User.create', error)
+    }
   },
 
   async update (kvChanges) {

--- a/src/routes/[user]/+layout.svelte
+++ b/src/routes/[user]/+layout.svelte
@@ -4,8 +4,9 @@
   import ExtendRoutines from '/src/routes/[user]/components/ExtendRoutines.svelte'
   import { doc, onSnapshot } from 'firebase/firestore'
   import { db } from '$lib/db/init'
-  import { user, clickedTaskID } from '$lib/store'
+  import { user, clickedTaskID, firebaseAuth } from '$lib/store'
   import { onMount, onDestroy, getContext } from 'svelte'
+  import { get } from 'svelte/store'
   import { page } from '$app/state'
 
   let { children } = $props()
@@ -21,10 +22,16 @@
   function listenToUser () {
     const ref = doc(db, '/users/' + uid)
     unsub = onSnapshot(ref, async (snap) => {
-      if (!snap.exists()) User.create()
-      else {
-        user.set({ ...snap.data() })
-      }
+      if (!snap.exists()) {
+        const authUID = get(firebaseAuth).currentUser?.uid
+        // Avoid creating docs off stale cache snapshots or wrong route params.
+        if (authUID === uid && !snap.metadata.fromCache) await User.create()
+        return
+      } 
+
+      user.set({ ...snap.data() })
+    }, (error) => {
+      console.error('Error listening to user doc:', error)
     })
   }
 </script>

--- a/src/routes/[user]/components/TaskPopup/ColorTags.svelte
+++ b/src/routes/[user]/components/TaskPopup/ColorTags.svelte
@@ -1,9 +1,8 @@
 <script>
   import PopoverMenu from '$lib/components/PopoverMenu.svelte'
   import Task from '$lib/db/models/Task';
-  import User from '$lib/db/models/User'
   import MslMoreVert from 'virtual:icons/material-symbols-light/more-vert'
-  import { deleteColorTag } from '$lib/db/helpers.js'
+  import { createColorTag, updateColorTag, deleteColorTag } from '$lib/db/helpers.js'
   import { user } from '$lib/store'
   import { getRandomID, getRandomColor } from '$lib/utils/core.js'
   import { paddingVal } from '$lib/styles/reused.module.css'
@@ -22,19 +21,22 @@
     '#8E6B8E', // plum
   ]
 
-  function onkeyup (e) {
+  async function onkeyup (e) {
     if (e.key === 'Enter') {
-      if (value === '') {
+      const name = value.trim()
+      if (name === '' || !$user.uid) {
         return
       }
-      const copy = { ...$user.tags }
       const id = getRandomID()
-      copy[id] = {
-        color: getRandomColor(),
-        name: e.target.value
-      }
+      await createColorTag({
+        uid: $user.uid,
+        tagID: id,
+        tag: {
+          color: getRandomColor(),
+          name
+        }
+      })
 
-      User.update({ tags: copy })
       Task.update({
         id: task.id,
         kvChanges: {
@@ -60,12 +62,10 @@
   }
 
   function editTag (id, kvChanges) {
-    const copy = { ...$user.tags }
-    for (const [k, v] of Object.entries(kvChanges)) {
-      copy[id][k] = v
-    }
-    User.update({
-      tags: copy
+    updateColorTag({
+      uid: $user.uid,
+      tagID: id,
+      kvChanges
     })
   }
 </script>
@@ -139,7 +139,7 @@
                 </div>
             
                 <div class="py-1 px-2">
-                  <button onclick={() => deleteColorTag({ tagID: id, user: $user })}>
+                  <button onclick={() => deleteColorTag({ tagID: id, uid: $user.uid })}>
                     Delete
                   </button>  
                 </div>


### PR DESCRIPTION
Harden `user.tags` against accidental wipes by implementing atomic tag updates and safer user creation checks.

Previously, `user.tags` could be wiped to `{}` via two non-migration runtime paths:
1.  Tag CRUD operations in `ColorTags.svelte` and `deleteColorTag` performed full-map overwrites, risking an empty `{}` write if local `$user.tags` state was stale.
2.  The `User.create()` function, when called from `[user]/+layout.svelte` for a missing user document, would set default `tags: {}`, potentially clobbering existing tags if triggered unexpectedly.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-9847a161-96c8-406d-9f73-0b13a5373471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9847a161-96c8-406d-9f73-0b13a5373471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

