### PR TITLE
Routine generation mechanism

### DIFF
--- a/src/lib/utils/rrule.js
+++ b/src/lib/utils/rrule.js
@@ -13,10 +13,16 @@ function rrFloat (dt) {
 }
 
 export function generateRecurrenceDTs ({ startDT, endDT, rrStr }) {
+  if (!rrStr || !startDT?.isValid || !endDT?.isValid) {
+    return []
+  }
+
+  // Use [start of start day, start of day after end day) so occurrences
+  // later in the end day are included even when rrule carries a time component.
   const jsDates = RRule.fromString(rrStr).between(
-    rrFloat(startDT),
-    rrFloat(endDT),
-    true // includes endDT
+    rrFloat(startDT.startOf('day')),
+    rrFloat(endDT.plus({ days: 1 }).startOf('day')),
+    false
   )
   const results = jsDates.map(date => {
     // from rrule's README (seriously)

--- a/src/routes/[user]/components/ExtendRoutines.svelte
+++ b/src/routes/[user]/components/ExtendRoutines.svelte
@@ -8,36 +8,61 @@
   const { User, Template } = getContext('app')
 
   onMount(async () => {
-    const today = DateTime.utc().toFormat('yyyy-MM-dd')
-    if (today > $user.lastRanRoutines) { 
-      const templates = await Template.getAll()
-      
-      await Promise.all(
-        templates
-          .filter(t => t.rrStr)
-          .map(template => 
-            extendRoutine({ 
-              startDT: DateTime.fromISO(template.prevEndISO).plus({ days: 1 }),
-              endDT: DateTime.utc().plus({ days: template.previewSpan ?? 14 }),
-              template
-            }).catch(e => console.error(`Failed to extend template ${template.id}:`, e))
-          )
-      )
-      
-      await User.update({ lastRanRoutines: today })
+    const todayISO = DateTime.utc().toFormat('yyyy-MM-dd')
+    if (todayISO <= $user.lastRanRoutines) {
+      return
     }
+
+    const templates = (await Template.getAll()).filter(template => template.rrStr)
+    const failures = []
+
+    for (const template of templates) {
+      try {
+        await extendRoutine({ template })
+      } catch (error) {
+        failures.push({
+          templateID: template.id,
+          error: error?.message ?? String(error)
+        })
+      }
+    }
+
+    if (failures.length > 0) {
+      console.error('Routine auto-extension failures. Keeping lastRanRoutines unchanged for retry.', failures)
+      return
+    }
+
+    await User.update({ lastRanRoutines: todayISO })
   })
 
-  async function extendRoutine ({ startDT, endDT, template }) {
+  async function extendRoutine ({ template }) {
+    const endDT = DateTime.utc().plus({ days: template.previewSpan ?? 14 }).startOf('day')
+    const startDT = getStartDT(template)
+    if (startDT.toMillis() > endDT.toMillis()) {
+      return
+    }
+
     const matchingDTs = generateRecurrenceDTs({ 
       startDT, endDT, rrStr: template.rrStr 
     })
+
     await Promise.all(
       matchingDTs.map(dt => createTaskInstance({ template, dt }))
     )
+
     await Template.update({ 
       id: template.id, 
       updates: { prevEndISO: endDT.toFormat('yyyy-MM-dd') }
     })
+  }
+
+  function getStartDT (template) {
+    const prevEndDT = DateTime.fromISO(template.prevEndISO)
+    if (prevEndDT.isValid) {
+      return prevEndDT.plus({ days: 1 }).startOf('day')
+    }
+
+    console.warn(`Template ${template.id} has invalid prevEndISO "${template.prevEndISO}". Falling back to today.`)
+    return DateTime.utc().startOf('day')
   }
 </script>

--- a/src/routes/[user]/components/Templates/components/TemplatePopup/instances.js
+++ b/src/routes/[user]/components/Templates/components/TemplatePopup/instances.js
@@ -29,6 +29,11 @@ export function createTaskInstance ({ template, dt }) {
     id: template.id + '_' + dt.toFormat('yyyy-MM-dd'),
     newTaskObj: instantiateTask({ template, dt }),
     optimistic: false
+  }).then(result => {
+    if (result instanceof Error) {
+      throw result
+    }
+    return result
   })
 }
 


### PR DESCRIPTION
Fixes routine auto-extension by correcting recurrence date range matching and hardening the extension flow.

Previously, 1-day extension windows (after initial generation) silently failed to generate tasks due to incorrect midnight-to-midnight recurrence matching. This systematically excluded all occurrences with a time component on the end day, leading to zero tasks being generated while still advancing internal state (`prevEndISO`, `lastRanRoutines`).

---
<p><a href="https://cursor.com/background-agent?bcId=bc-54d2eb90-dc90-4406-be24-bfeeca71bc86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-54d2eb90-dc90-4406-be24-bfeeca71bc86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

