### PR TITLE
Image task keyboard closing

### DIFF
--- a/src/routes/[user]/components/TaskPopup/LayoutDecider.svelte
+++ b/src/routes/[user]/components/TaskPopup/LayoutDecider.svelte
@@ -5,56 +5,108 @@
   let { task, photo, info } = $props()
 
   const { PANEL_MAX } = WIDTHS
+  const photoWidth = PANEL_MAX / goldenRatio
   let desktop = $derived(innerWidth.current >= breakpoints.desktop)
+  let imageDownloadURL = $derived(task?.imageDownloadURL ?? '')
+  let aspectRatio = $state(null)
 
-  async function getAspectRatio (src) {
-    const img = new Image()
-    img.src = src
-    await img.decode()
-    return img.naturalWidth / img.naturalHeight
+  // Keep this memoized so realtime task updates do not retrigger async layout resets.
+  const aspectRatioCache = new Map()
+  const inFlightAspectRatioRequests = new Map()
+
+  function readAspectRatio (src) {
+    if (aspectRatioCache.has(src)) {
+      return Promise.resolve(aspectRatioCache.get(src))
+    }
+
+    if (inFlightAspectRatioRequests.has(src)) {
+      return inFlightAspectRatioRequests.get(src)
+    }
+
+    const request = (async () => {
+      const img = new Image()
+      img.src = src
+      await img.decode()
+      const ratio = img.naturalWidth / img.naturalHeight
+      aspectRatioCache.set(src, ratio)
+      return ratio
+    })().finally(() => {
+      inFlightAspectRatioRequests.delete(src)
+    })
+
+    inFlightAspectRatioRequests.set(src, request)
+    return request
   }
+
+  $effect(() => {
+    const src = imageDownloadURL
+    if (!src) {
+      aspectRatio = null
+      return
+    }
+
+    if (aspectRatioCache.has(src)) {
+      aspectRatio = aspectRatioCache.get(src)
+      return
+    }
+
+    aspectRatio = null
+    let cancelled = false
+
+    readAspectRatio(src)
+      .then(ratio => {
+        if (!cancelled && src === imageDownloadURL) {
+          aspectRatio = ratio
+        }
+      })
+      .catch(() => {
+        if (!cancelled && src === imageDownloadURL) {
+          aspectRatio = null
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  })
 </script>
 
 {#if task}
   {@const { imageDownloadURL, photoLayout } = task}
 
   {#if imageDownloadURL}
-    {#await getAspectRatio(imageDownloadURL) then aspectRatio}
-      {#if photoLayout === 'full-photo'}
-        {@render photo(`max-width: 100vw; max-height: ${!desktop ? '80dvh' : '100dvh'}`)}
+    {#if photoLayout === 'full-photo'}
+      {@render photo(`max-width: 100vw; max-height: ${!desktop ? '80dvh' : '100dvh'}`)}
+    {:else}
+      {#if !desktop}
+        <div style="max-height: 80dvh; width: 100vw; max-width: {PANEL_MAX}px">
+          {@render photo("width: 100%; height: 40dvh; object-fit: cover;")}
+          <div style="width: 100%; padding: 12px;">
+            {@render info()}
+          </div>
+        </div>
       {:else}
-        {#if !desktop}
-          <div style="max-height: 80dvh; width: 100vw; max-width: {PANEL_MAX}px">
-            {@render photo("width: 100%; height: 40dvh; object-fit: cover;")}
-            <div style="width: 100%; padding: 12px;">
+        {#if aspectRatio !== null && aspectRatio > 1} <!-- top landscape -->
+          {@render photo(`width: ${PANEL_MAX}px; object-fit: cover;`)}
+          <div style="width: {PANEL_MAX}px; padding: 12px;">
+            {@render info()}
+          </div>
+        {:else} <!-- left portrait (or fallback while loading) -->
+          <div style="display: flex;">
+            {@render photo(`width: ${photoWidth}px; object-fit: cover;`)}
+            <div style="
+              width: {PANEL_MAX}px;
+              max-height: {aspectRatio !== null ? `${photoWidth * (1 / aspectRatio)}px` : '80dvh'}; 
+              overflow-y: auto;
+              padding: 12px 16px;"
+              class="hide-scrollbar"
+            >
               {@render info()}
             </div>
           </div>
-        {:else}      
-          {#if aspectRatio <= 1} <!-- left portrait -->
-            {@const photoWidth = PANEL_MAX / goldenRatio}
-            <div style="display: flex;">
-          
-              {@render photo(`width: ${photoWidth}px; object-fit: cover;`)}
-              <div style="
-                width: {PANEL_MAX}px;
-                max-height: {photoWidth * 1/aspectRatio}px; 
-                overflow-y: auto;
-                padding: 12px 16px;"
-                class="hide-scrollbar"
-              >
-                {@render info()}
-              </div>
-            </div>  
-          {:else if aspectRatio > 1} <!-- top landscape -->
-            {@render photo(`width: ${PANEL_MAX}px; object-fit: cover;`)}
-            <div style="width: {PANEL_MAX}px; padding: 12px;">
-              {@render info()}
-            </div>
-          {/if}
         {/if}
       {/if}
-    {/await}
+    {/if}
   {:else}
     {#if innerWidth.current < breakpoints.desktop}
       <div style="max-height: 80dvh; width: 100vw; max-width: {PANEL_MAX}px; padding: 12px;">


### PR DESCRIPTION
Refactor `LayoutDecider.svelte` to keep `Details` (title input) mounted and memoize image aspect ratio.

The iOS keyboard was closing for image tasks after a debounced title update because the `{#await getAspectRatio(...)` block in `LayoutDecider.svelte` caused the `Details` component (containing the title input) to unmount and remount, leading to focus loss. This change ensures the title input remains mounted, preserving focus.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-b207b813-bf0a-4fe7-8381-cb9e6813a720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b207b813-bf0a-4fe7-8381-cb9e6813a720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

