### PR TITLE
Fix duplicated routine subtasks and delete batch conflict

### DIFF
--- a/src/lib/db/models/Template.js
+++ b/src/lib/db/models/Template.js
@@ -141,6 +141,7 @@ const Template = {
     const allTemplates = await getFirestoreCollection(`/users/${get(user).uid}/templates`)
     const newTreeID = idempotentISO ? `${template.id}_${idempotentISO}` : randomID()
     const { parentID } = modifiers
+    const useIdempotentIDs = Boolean(idempotentISO)
 
     return helper({ 
       node: { ...template, ...modifiers }, 
@@ -150,11 +151,13 @@ const Template = {
       templateID: (typeof template.rrStr === 'string') ? template.id : '',
       onList: !!modifiers.onList, // `template.onList` doesn't matter, example: calendar task forged into a template, which instantiates onto the list.
       memo: nodesByParent(allTemplates.filter(T => T.rootID === template.rootID)),
+      idempotentISO,
+      useIdempotentIDs
     })
   }
 }
 
-async function helper ({ node, id, parentID, rootID, templateID, onList, memo }) {
+async function helper ({ node, id, parentID, rootID, templateID, onList, memo, idempotentISO, useIdempotentIDs }) {
   const result = await Task.create({ id, data: { 
     ...node, parentID, rootID, templateID, onList
   }}) 
@@ -162,14 +165,20 @@ async function helper ({ node, id, parentID, rootID, templateID, onList, memo })
 
   // treeISOs will be maintained by Task.create() as long as `parent` and `tasksCache` are created before children
   for (const child of memo[node.id]) {
-    helper({ 
+    const childTaskID = (useIdempotentIDs && idempotentISO)
+      ? `${child.id}_${idempotentISO}`
+      : randomID()
+
+    await helper({ 
       node: child, 
       parentID: id,
       rootID,  
-      id: randomID(), 
+      id: childTaskID,
       templateID: '',
       onList,
-      memo
+      memo,
+      idempotentISO,
+      useIdempotentIDs
     })
   }
   return result

--- a/src/lib/db/models/treeISOs.js
+++ b/src/lib/db/models/treeISOs.js
@@ -148,16 +148,15 @@ export function removeOneInstance (array, item) {
 export async function handleTreeISOsForDeletion ({ tasksToDelete, batch }) {
   if (!tasksToDelete || !tasksToDelete.length) return
   
+  const deletedIDs = new Set(tasksToDelete.map(task => task.id))
   const tasksByRoot = {}
 
   for (const task of tasksToDelete) {
-    if (!task.treeISOs.length) continue
-    
     const root = await getRoot(task)
+    if (!root) continue
     if (!tasksByRoot[root.id]) {
       tasksByRoot[root.id] = { 
         root, 
-        tasksToRemove: [], 
         datesToRemove: [] 
       }
     }
@@ -165,11 +164,10 @@ export async function handleTreeISOsForDeletion ({ tasksToDelete, batch }) {
     if (task.startDateISO) {
       tasksByRoot[root.id].datesToRemove.push(task.startDateISO)
     }
-    tasksByRoot[root.id].tasksToRemove.push(task)
   }
   
   for (const rootID in tasksByRoot) {
-    const { root, tasksToRemove, datesToRemove } = tasksByRoot[rootID]
+    const { root, datesToRemove } = tasksByRoot[rootID]
     
     if (!root.treeISOs.length) continue
     
@@ -178,9 +176,7 @@ export async function handleTreeISOsForDeletion ({ tasksToDelete, batch }) {
       newTreeISOs = removeOneInstance(newTreeISOs, date)
     }
     const allTreeNodes = await getSubtreeNodes(root)
-    const remainingNodes = allTreeNodes.filter(node => 
-      !tasksToRemove.some(task => task.id === node.id)
-    )
+    const remainingNodes = allTreeNodes.filter(node => !deletedIDs.has(node.id))
     for (const node of remainingNodes) {
       const ref = doc(db, `/users/${get(user).uid}/tasks/${node.id}`)
       batch.update(ref, { treeISOs: newTreeISOs })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make routine instantiation idempotent for **all** nodes in the tree when `idempotentISO` is used (previously only the root ID was deterministic)
- await recursive child instantiation so subtree creation completes deterministically and cache ordering is stable
- harden `handleTreeISOsForDeletion` to never `update` any task doc that is already scheduled for `delete` in the same batch

## Root cause
- routine extension (`Template.instantiateTree`) generated a deterministic ID for the root task (`templateID_date`) but assigned random IDs to child subtasks
- when extension reran for the same date (e.g. repeated clients/retries), the root doc was overwritten but new child subtasks were appended, causing inflated subtask counts in `TaskPopup`
- on deletion, tree ISO maintenance could attempt to update docs that were being deleted in the same write batch, triggering Firestore error: `Cannot delete then update an entity in the same request.`

## Validation
- `npm run build` passes successfully after changes
- no new lint/build errors introduced by modified files

## Notes
- this change prevents future duplicate subtasks for idempotent routine instances
- existing already-duplicated data may still need one-time cleanup (manual delete should now complete without the batch conflict)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c7c796b-6a11-49f7-9a62-1b07d85772b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c7c796b-6a11-49f7-9a62-1b07d85772b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

