### PR TITLE
Fix Safari popover input invisibility with stricter anchor feature detection

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -18,17 +18,43 @@
 
   let { children } = $props()
 
+  function supportsPopoverAPI () {
+    return (
+      'popover' in HTMLElement.prototype &&
+      'showPopover' in HTMLElement.prototype &&
+      'hidePopover' in HTMLElement.prototype &&
+      'togglePopover' in HTMLElement.prototype
+    )
+  }
+
+  function supportsAnchorPositioningForPopoverInput () {
+    if (typeof CSS === 'undefined' || typeof CSS.supports !== 'function') return false
+
+    const requiredFeatures = [
+      'anchor-name: --x',
+      'position-anchor: --x',
+      'top: anchor(bottom)',
+      'left: anchor(left)',
+      'width: anchor-size(width)',
+      'height: anchor-size(height)',
+      'position-area: center'
+    ]
+
+    return requiredFeatures.every((feature) => CSS.supports(feature))
+  }
+
   $effect(() => {
     if ($authChecked && $loggedIn && $user.email && $initialDataReady) {
       loading.set(false)
     }
   })
 
-  onMount(async () => {    
-    if (!HTMLElement.prototype.hasOwnProperty("popover")) {
+  onMount(async () => {
+    if (!supportsPopoverAPI()) {
       await import('@oddbird/popover-polyfill')
     }
-    if (!CSS.supports('anchor-name: --x')) {
+    // Safari can report partial anchor support while missing anchor-size()/position-area.
+    if (!supportsAnchorPositioningForPopoverInput()) {
       const { default: anchorPolyfill } = await import('@oddbird/css-anchor-positioning/fn')
       await anchorPolyfill()
     }
@@ -86,6 +112,7 @@
 
 {#if $loading} <!-- must be separate from the transition block -->
   <img src="/logo-no-bg.png" 
+    alt="Loading logo"
     class={['pulse center', 'w-12 h-12 rounded-2xl']}
   />
 {/if}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- harden client-side popover API detection to check for the full popover method surface
- replace single `anchor-name` feature gate with a full anchor-positioning capability check used by `PopoverInputContext` (`position-anchor`, `anchor()`, `anchor-size()`, and `position-area`)
- load `@oddbird/css-anchor-positioning/fn` whenever any required anchor capability is missing (e.g. Safari partial implementations)
- add a missing loading image `alt` attribute in `+layout.svelte`

## Why
Safari can report partial anchor-positioning support while still lacking key features used by the task input popover. In that state, the input can receive focus (keyboard opens) but render at zero/invalid geometry, so the blue input box appears invisible.

## Validation
- Svelte MCP `svelte-autofixer` run on `+layout.svelte` after edits
- local build/test run follows in this iteration
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f80e40d7-b160-4b0f-aa1a-1e3efd6ab01f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f80e40d7-b160-4b0f-aa1a-1e3efd6ab01f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

