### PR TITLE
Show browser warning without blocking login on outdated browsers

### DIFF
--- a/src/routes/(home)/+page.svelte
+++ b/src/routes/(home)/+page.svelte
@@ -6,14 +6,12 @@
   import MacbookDisplay from './components/MacbookDisplay.svelte'
   import PhoneDisplay from './components/PhoneDisplay.svelte'
   import AuthPlayground from './components/AuthPlayground.svelte'
-  import LogosChrome from 'virtual:icons/logos/chrome'
-  import LogosSafari from 'virtual:icons/logos/safari'
   import { authChecked, authUser } from '$lib/store'
   import { isMobile } from '$lib/utils/core.js'
   import { browser } from '$app/environment'
   import { onMount } from 'svelte'
 
-  let browserSupported = $state(false)
+  let browserSupported = $state(true)
 
   onMount(() => {
     browserSupported = HTMLElement.prototype.hasOwnProperty("popover")
@@ -41,6 +39,12 @@
 
     <IntegrationCards />
 
+    {#if !browserSupported}
+      <p class="text-center text-amber-700 px-4 max-w-[60ch]">
+        WARNING: some features may not work on your browser. Please use the latest Chrome or Safari.
+      </p>
+    {/if}
+
     {#if browser && isMobile()}
       <PhoneDisplay children={simulatedApp} />
     {:else}
@@ -48,38 +52,20 @@
     {/if}
 
     {#snippet simulatedApp ()}
-      {#if browserSupported}
-        <div class="w-full h-full relative">
-          {#if $authChecked && !$authUser?.email}
-            <AnonymousContext>
-              {#snippet children (uid)}
-                {#if uid}
-                  <UserAppInstance {uid} />
-                {/if}
-              {/snippet}
-            </AnonymousContext>
-          {/if}
-        </div>
-      {:else}
-        <div class="relative w-full h-full bg-white flex flex-col items-center justify-center">
-          <p>WARNING: the app can't run on your browser and requires the latest version of Chrome or Safari</p>
-          <div class="flex items-center gap-4">
-            <div class="flex items-center justify-center size-12">
-              <LogosChrome class="w-[4.4rem] h-[4.4rem] drop-shadow-sm" />
-            </div>
-            <div class="flex items-center justify-center size-13">
-              <LogosSafari class="w-20 h-20 drop-shadow-sm" />
-            </div>
-          </div>
-        </div>
-      {/if}
+      <div class="w-full h-full relative">
+        {#if $authChecked && !$authUser?.email}
+          <AnonymousContext>
+            {#snippet children (uid)}
+              {#if uid}
+                <UserAppInstance {uid} />
+              {/if}
+            {/snippet}
+          </AnonymousContext>
+        {/if}
+      </div>
     {/snippet}
 
-    {#if browserSupported}
-      <AuthPlayground/>
-    {:else}
-      <p>WARNING: the app can't run on your browser and requires the latest version of Chrome or Safari</p>
-    {/if}
+    <AuthPlayground/>
 
     <footer class="w-full mt-40 py-8 flex justify-end mr-10 gap-6 text-xs text-neutral-400 tracking-tight">
       <a href="/legal/privacy-policy" class="no-underline">Privacy</a>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The home page previously blocked both the demo app preview and Google sign-in when the browser lacked popover/anchor-name support. This change shows a single warning banner instead while keeping login and the demo available.

## Changes

- Removed `{#if browserSupported}` gates around `AnonymousContext` / `UserAppInstance` and `AuthPlayground`
- Replaced duplicate blocking UI (including Chrome/Safari logo panel) with one warning message
- Default `browserSupported` to `true` so supported browsers are not warned before `onMount` runs

Net: **14 fewer lines** in `src/routes/(home)/+page.svelte` (90 → 76).

## Testing

- [ ] Open home page in a current Chrome/Safari — no warning, demo and sign-in work
- [ ] Simulate unsupported browser (or use an older browser) — warning appears, demo and sign-in still visible
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e517d6bc-153f-4313-ac28-cfe6d0ad6aaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e517d6bc-153f-4313-ac28-cfe6d0ad6aaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

