### PR TITLE
Unify Google login and Calendar under GIS

### DIFF
--- a/functions/googleCalendar.js
+++ b/functions/googleCalendar.js
@@ -34,26 +34,26 @@ exports.exchangeGoogleCode = onCall({ cors: true, secrets: [GOOGLE_CLIENT_SECRET
     const googleUserId = payload.sub
     const googleEmail = payload.email
 
-    const ref = db.doc(`users/${request.auth.uid}/googleAccounts/${googleUserId}`)
-     
-    // TO-DO: use factory functions instead of misusing Zod
-    await ref.set({
-      email: googleEmail,
-      id: googleUserId,
-      refreshToken: { 
-        value: tokens.refresh_token,
-        lastUsed: '' // after 6 months of inactivity
-      },
-      accessToken: {
-        value: tokens.access_token,
-        expiryDate: tokens.expiry_date // 1 hour after issuance
-      },
-      scope: tokens.scope,
-      selectedCalIDs: [],
-      opacity: 0.9
-    }, { merge: true })
+    if (tokens.scope?.includes('calendar') && tokens.refresh_token) {
+      const ref = db.doc(`users/${request.auth.uid}/googleAccounts/${googleUserId}`)
+      await ref.set({
+        email: googleEmail,
+        id: googleUserId,
+        refreshToken: {
+          value: tokens.refresh_token,
+          lastUsed: '',
+        },
+        accessToken: {
+          value: tokens.access_token,
+          expiryDate: tokens.expiry_date,
+        },
+        scope: tokens.scope,
+        selectedCalIDs: [],
+        opacity: 0.9,
+      }, { merge: true })
+    }
 
-    return { success: true, googleUserId, email: googleEmail }
+    return { success: true, googleUserId, email: googleEmail, idToken: tokens.id_token }
   } catch (error) {
     console.error('Error exchanging token:', error);
     throw new HttpsError('internal', 'Failed to exchange authorization code', error.message);

--- a/src/lib/auth/anonymous.js
+++ b/src/lib/auth/anonymous.js
@@ -1,0 +1,24 @@
+import { signInAnonymously, getAdditionalUserInfo } from 'firebase/auth'
+import { get } from 'svelte/store'
+import { firebaseAuth, user } from '$lib/store'
+import User from '$lib/db/models/User.js'
+import { initializeSeedData } from '$lib/db/seed.js'
+
+/** Ensures a Firebase anonymous session exists (for demo or before linking Google). */
+export async function ensureAnonymousSession () {
+  const auth = get(firebaseAuth)
+  if (auth.currentUser?.isAnonymous) {
+    if (!get(user).uid) user.set({ uid: auth.currentUser.uid })
+    return auth.currentUser
+  }
+
+  const result = await signInAnonymously(auth)
+  if (getAdditionalUserInfo(result).isNewUser) {
+    const mirrorDoc = await User.create(auth.currentUser)
+    user.set(mirrorDoc)
+    await initializeSeedData()
+  } else if (!get(user).uid) {
+    user.set({ uid: result.user.uid })
+  }
+  return result.user
+}

--- a/src/lib/features/google-calendar/AddAccount.svelte
+++ b/src/lib/features/google-calendar/AddAccount.svelte
@@ -1,24 +1,20 @@
 <script>
-  import { initiateGoogleConnect, loadGoogleIdentityServices } from '$lib/features/google-calendar/GIS.js'
+  import { connectGoogleCalendar } from '$lib/features/google-calendar/GIS.js'
   import GoogleIdentityButton from '$lib/components/GoogleIdentityButton.svelte'
-  
-  // Ideally, expose this via a public environment variable in SvelteKit ($env/static/public)
-  const clientId = '132745397287-aakar5npr4orq496580pdgpvqeupf6j5.apps.googleusercontent.com'
+
   let loading = $state(false)
   let error = $state('')
 
-  async function handleConnect() {
+  async function handleConnect () {
     loading = true
     error = ''
     try {
-      await loadGoogleIdentityServices()
-      await initiateGoogleConnect(clientId)
+      await connectGoogleCalendar()
       window.location.reload()
     } catch (err) {
       console.error(err)
       error = err.message
     } finally {
-      console.log('finally clause')
       loading = false
     }
   }

--- a/src/lib/features/google-calendar/AddAccount.svelte
+++ b/src/lib/features/google-calendar/AddAccount.svelte
@@ -10,11 +10,9 @@
     error = ''
     try {
       await connectGoogleCalendar()
-      window.location.reload()
     } catch (err) {
       console.error(err)
       error = err.message
-    } finally {
       loading = false
     }
   }

--- a/src/lib/features/google-calendar/GIS.js
+++ b/src/lib/features/google-calendar/GIS.js
@@ -13,9 +13,15 @@ import { ensureAnonymousSession } from '$lib/auth/anonymous.js'
 export const GOOGLE_CLIENT_ID =
   '132745397287-aakar5npr4orq496580pdgpvqeupf6j5.apps.googleusercontent.com'
 
+const OAUTH_STORAGE_KEY = 'google_oauth_pending'
+
 const SCOPES = {
   login: 'openid email profile',
   calendar: 'https://www.googleapis.com/auth/calendar openid email',
+}
+
+export function getGoogleRedirectUri () {
+  return `${window.location.origin}/auth/google/callback`
 }
 
 export function loadGoogleIdentityServices () {
@@ -30,47 +36,68 @@ export function loadGoogleIdentityServices () {
   })
 }
 
-function requestGoogleAuthCode (scope) {
-  return new Promise((resolve, reject) => {
-    const client = google.accounts.oauth2.initCodeClient({
-      client_id: GOOGLE_CLIENT_ID,
-      scope,
-      ux_mode: 'popup',
-      callback: (response) => {
-        if (response.code) resolve(response.code)
-        else reject(new Error(response.error || 'Authorization failed'))
-      },
-      error_callback: (error) => {
-        reject(new Error(error.type === 'popup_closed' ? 'Authorization cancelled' : error.message))
-      },
-    })
-    client.requestCode()
-  })
+function savePendingOAuth (pending) {
+  sessionStorage.setItem(OAUTH_STORAGE_KEY, JSON.stringify(pending))
 }
 
-async function exchangeCode (code) {
-  const { data } = await cloudFunction('exchangeGoogleCode', { code })
+function consumePendingOAuth () {
+  const raw = sessionStorage.getItem(OAUTH_STORAGE_KEY)
+  sessionStorage.removeItem(OAUTH_STORAGE_KEY)
+  if (!raw) throw new Error('OAuth session expired. Please try again.')
+  return JSON.parse(raw)
+}
+
+async function exchangeCode (code, redirect_uri) {
+  const { data } = await cloudFunction('exchangeGoogleCode', { code, redirect_uri })
   return data
 }
 
-/** GIS sign-in: anonymous session first, then link Google (same uid, keeps demo data). */
-export async function signInWithGoogle () {
-  await ensureAnonymousSession()
+/** Full-page redirect to Google (WebKit-safe). Resumes on /auth/google/callback. */
+export async function startGoogleAuth (flow, { returnTo } = {}) {
+  if (flow === 'login') await ensureAnonymousSession()
   await loadGoogleIdentityServices()
-  const { idToken, email } = await exchangeCode(await requestGoogleAuthCode(SCOPES.login))
-  const auth = get(firebaseAuth)
-  const credential = GoogleAuthProvider.credential(idToken)
-  try {
-    await linkWithCredential(auth.currentUser, credential)
-  } catch (e) {
-    if (e.code === AuthErrorCodes.CREDENTIAL_ALREADY_IN_USE) {
-      await signInWithCredential(auth, credential)
-    } else throw e
-  }
-  await User.update({ email })
+
+  const state = crypto.randomUUID()
+  savePendingOAuth({ flow, state, returnTo: returnTo || null })
+
+  google.accounts.oauth2.initCodeClient({
+    client_id: GOOGLE_CLIENT_ID,
+    scope: SCOPES[flow],
+    ux_mode: 'redirect',
+    redirect_uri: getGoogleRedirectUri(),
+    state,
+  }).requestCode()
 }
 
-export async function connectGoogleCalendar () {
-  await loadGoogleIdentityServices()
-  await exchangeCode(await requestGoogleAuthCode(SCOPES.calendar))
+/** GIS sign-in: anonymous first, then link Google on callback (same uid). */
+export function signInWithGoogle () {
+  return startGoogleAuth('login')
+}
+
+export function connectGoogleCalendar () {
+  const returnTo = typeof window !== 'undefined' ? window.location.pathname : null
+  return startGoogleAuth('calendar', { returnTo })
+}
+
+export async function completeGoogleAuth (code, urlState) {
+  const { flow, state, returnTo } = consumePendingOAuth()
+  if (urlState !== state) throw new Error('Invalid OAuth state')
+
+  const redirect_uri = getGoogleRedirectUri()
+  const { idToken } = await exchangeCode(code, redirect_uri)
+  const auth = get(firebaseAuth)
+
+  if (flow === 'login') {
+    const credential = GoogleAuthProvider.credential(idToken)
+    try {
+      await linkWithCredential(auth.currentUser, credential)
+    } catch (e) {
+      if (e.code === AuthErrorCodes.CREDENTIAL_ALREADY_IN_USE) {
+        await signInWithCredential(auth, credential)
+      } else throw e
+    }
+    await User.update({ email: auth.currentUser.email })
+  }
+
+  return { redirectTo: returnTo || `/${auth.currentUser.uid}` }
 }

--- a/src/lib/features/google-calendar/GIS.js
+++ b/src/lib/features/google-calendar/GIS.js
@@ -1,51 +1,24 @@
 import { cloudFunction } from '$lib/utils/cloudFunctions.js'
+import { firebaseAuth } from '$lib/store'
+import { get } from 'svelte/store'
+import {
+  AuthErrorCodes,
+  GoogleAuthProvider,
+  linkWithCredential,
+  signInWithCredential,
+} from 'firebase/auth'
+import User from '$lib/db/models/User.js'
 
-/**
- * Initiates the Google OAuth2 Authorization Code Flow.
- * @param {string} clientId - Your Google Cloud Client ID.
- * @param {string} scope - Space-separated list of scopes.
- * @returns {Promise<void>}
- */
-export function initiateGoogleConnect (clientId, scope = 'https://www.googleapis.com/auth/calendar openid email') {
-  return new Promise((resolve, reject) => {
-    if (typeof google === 'undefined' || !google.accounts || !google.accounts.oauth2) {
-      reject(new Error('Google Identity Services script not loaded.'))
-      return
-    }
+export const GOOGLE_CLIENT_ID =
+  '132745397287-aakar5npr4orq496580pdgpvqeupf6j5.apps.googleusercontent.com'
 
-    const client = google.accounts.oauth2.initCodeClient({
-      client_id: clientId,
-      scope: scope,
-      ux_mode: 'popup',
-      callback: async (response) => {
-        if (response.code) {
-          try {
-            console.log('Received auth code, exchanging for tokens...')
-            await cloudFunction('exchangeGoogleCode', { code: response.code })
-            resolve()
-          } catch (error) {
-            console.error('Error exchanging code:', error)
-            reject(error)
-          }
-        } else if (response.error) {
-          console.error('GIS Error:', response.error)
-          reject(new Error(response.error))
-        } else {
-          console.log('Unknown callback error, response =', response)
-          reject(new Error('Unknown callback error'))
-        }
-      },
-      error_callback: (error) => {
-        console.error('GIS Error Callback:', error);
-        reject(new Error(error.type === 'popup_closed' ? 'Authorization cancelled' : error.message));
-      }
-    })
-
-    client.requestCode()
-  })
+const SCOPES = {
+  login: 'openid email profile',
+  calendar: 'https://www.googleapis.com/auth/calendar openid email',
 }
 
 export function loadGoogleIdentityServices () {
+  if (typeof google !== 'undefined' && google.accounts?.oauth2) return Promise.resolve()
   return new Promise((resolve, reject) => {
     const script = document.createElement('script')
     script.src = 'https://accounts.google.com/gsi/client'
@@ -54,4 +27,47 @@ export function loadGoogleIdentityServices () {
     script.onerror = () => reject(new Error('Failed to load Google Identity Services script.'))
     document.head.appendChild(script)
   })
+}
+
+function requestGoogleAuthCode (scope) {
+  return new Promise((resolve, reject) => {
+    const client = google.accounts.oauth2.initCodeClient({
+      client_id: GOOGLE_CLIENT_ID,
+      scope,
+      ux_mode: 'popup',
+      callback: (response) => {
+        if (response.code) resolve(response.code)
+        else reject(new Error(response.error || 'Authorization failed'))
+      },
+      error_callback: (error) => {
+        reject(new Error(error.type === 'popup_closed' ? 'Authorization cancelled' : error.message))
+      },
+    })
+    client.requestCode()
+  })
+}
+
+async function exchangeCode (code) {
+  const { data } = await cloudFunction('exchangeGoogleCode', { code })
+  return data
+}
+
+export async function signInWithGoogle () {
+  await loadGoogleIdentityServices()
+  const { idToken, email } = await exchangeCode(await requestGoogleAuthCode(SCOPES.login))
+  const auth = get(firebaseAuth)
+  const credential = GoogleAuthProvider.credential(idToken)
+  try {
+    await linkWithCredential(auth.currentUser, credential)
+  } catch (e) {
+    if (e.code === AuthErrorCodes.CREDENTIAL_ALREADY_IN_USE) {
+      await signInWithCredential(auth, credential)
+    } else throw e
+  }
+  await User.update({ email })
+}
+
+export async function connectGoogleCalendar () {
+  await loadGoogleIdentityServices()
+  await exchangeCode(await requestGoogleAuthCode(SCOPES.calendar))
 }

--- a/src/lib/features/google-calendar/GIS.js
+++ b/src/lib/features/google-calendar/GIS.js
@@ -8,6 +8,7 @@ import {
   signInWithCredential,
 } from 'firebase/auth'
 import User from '$lib/db/models/User.js'
+import { ensureAnonymousSession } from '$lib/auth/anonymous.js'
 
 export const GOOGLE_CLIENT_ID =
   '132745397287-aakar5npr4orq496580pdgpvqeupf6j5.apps.googleusercontent.com'
@@ -52,7 +53,9 @@ async function exchangeCode (code) {
   return data
 }
 
+/** GIS sign-in: anonymous session first, then link Google (same uid, keeps demo data). */
 export async function signInWithGoogle () {
+  await ensureAnonymousSession()
   await loadGoogleIdentityServices()
   const { idToken, email } = await exchangeCode(await requestGoogleAuthCode(SCOPES.login))
   const auth = get(firebaseAuth)

--- a/src/routes/(home)/AnonymousContext.svelte
+++ b/src/routes/(home)/AnonymousContext.svelte
@@ -1,26 +1,13 @@
 <script>
-  import User from '$lib/db/models/User.js'
-  import { firebaseAuth, user } from '$lib/store'
-  import { 
-    signInAnonymously,
-    getAdditionalUserInfo,
-  } from 'firebase/auth'
+  import { ensureAnonymousSession } from '$lib/auth/anonymous.js'
   import { onMount } from 'svelte'
-  import { initializeSeedData } from '$lib/db/seed.js'
 
   let { children } = $props()
 
   let uid = $state('')
 
   onMount(async () => {
-    const result = await signInAnonymously($firebaseAuth)
-
-    if (getAdditionalUserInfo(result).isNewUser) {
-      const mirrorDoc = await User.create($firebaseAuth.currentUser) 
-      user.set(mirrorDoc) // needed to read $user.maxOrderValue for seed data
-      await initializeSeedData()
-    }
-    uid = result.user.uid
+    uid = (await ensureAnonymousSession()).uid
   })
 </script>
 

--- a/src/routes/(home)/components/AuthPlayground.svelte
+++ b/src/routes/(home)/components/AuthPlayground.svelte
@@ -1,34 +1,10 @@
 <script>
   import GoogleLogo from '$lib/components/GoogleLogo.svelte'
   import MslArrowOutward from 'virtual:icons/material-symbols-light/arrow-outward'
-  import {
-    AuthErrorCodes,
-    GoogleAuthProvider,
-    linkWithPopup,
-    signInWithCredential,
-    browserPopupRedirectResolver,
-  } from 'firebase/auth'
-  import { firebaseAuth } from '$lib/store'
-  import { get } from 'svelte/store'
-  import User from '$lib/db/models/User.js'
+  import { signInWithGoogle } from '$lib/features/google-calendar/GIS.js'
 
   async function onclick () {
-    try {
-      const result = await linkWithPopup(
-        get(firebaseAuth).currentUser,
-        new GoogleAuthProvider(),
-        browserPopupRedirectResolver
-      )
-      return User.update({ email: result.user.email })
-    } catch (e) {
-      if (e.code === AuthErrorCodes.CREDENTIAL_ALREADY_IN_USE) {
-        await signInWithCredential(
-          get(firebaseAuth),
-          GoogleAuthProvider.credentialFromError(e)
-        )
-      } 
-      else throw e
-    }
+    await signInWithGoogle()
   }
 </script>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -34,7 +34,7 @@
       authChecked.set(true) // from cookie, takes around 300 - 500ms
       authUser.set($firebaseAuth.currentUser)
 
-      if (page.url.pathname.startsWith('/legal')) {
+      if (page.url.pathname.startsWith('/legal') || page.url.pathname.startsWith('/auth/google')) {
         loading = false
       }
     

--- a/src/routes/auth/google/callback/+page.svelte
+++ b/src/routes/auth/google/callback/+page.svelte
@@ -1,0 +1,41 @@
+<script>
+  import { onMount } from 'svelte'
+  import { goto } from '$app/navigation'
+  import { page } from '$app/state'
+  import { completeGoogleAuth } from '$lib/features/google-calendar/GIS.js'
+
+  let error = $state('')
+
+  onMount(async () => {
+    const params = page.url.searchParams
+
+    if (params.get('error')) {
+      error = params.get('error_description') || params.get('error')
+      return
+    }
+
+    const code = params.get('code')
+    const state = params.get('state')
+    if (!code) {
+      error = 'No authorization code received'
+      return
+    }
+
+    try {
+      const { redirectTo } = await completeGoogleAuth(code, state)
+      await goto(redirectTo, { replaceState: true, invalidateAll: true })
+    } catch (err) {
+      console.error(err)
+      error = err.message
+    }
+  })
+</script>
+
+<div class="min-h-screen flex flex-col items-center justify-center gap-4 p-8 text-center">
+  {#if error}
+    <p class="text-red-600">{error}</p>
+    <a href="/" class="text-sm underline text-neutral-600">Back to home</a>
+  {:else}
+    <p class="text-neutral-600">Finishing sign-in…</p>
+  {/if}
+</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Unifies Google login and Calendar under GIS. Uses **full-page redirect** (not popup) for WebKit compatibility.

## Flow

1. `startGoogleAuth('login' | 'calendar')` → saves flow + CSRF `state` → `initCodeClient({ ux_mode: 'redirect' })` → browser leaves for Google
2. Google redirects to `/auth/google/callback?code=…&state=…`
3. `completeGoogleAuth()` → verifies state → `exchangeGoogleCode` with matching `redirect_uri` → link Google or store calendar tokens → redirect to app

Anonymous demo → link Google unchanged (`ensureAnonymousSession` before redirect).

## Config required

Add this **Authorized redirect URI** in Google Cloud Console (OAuth client):

- `https://<your-production-domain>/auth/google/callback`
- `http://localhost:5173/auth/google/callback` (or your dev port)

Must match `getGoogleRedirectUri()` exactly.

## Deploy

Redeploy Cloud Functions if not already on the branch that returns `idToken`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3224c193-7dce-4655-9397-ec67d1f0a829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3224c193-7dce-4655-9397-ec67d1f0a829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

